### PR TITLE
Fixes + allowing this repo to be used as an actual Home Assistant Add-On

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 
-CMD [ "/run.sh" ]
+CMD [ "run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM node:18-alpine
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+# Install requirements for add-on
+RUN \
+  apk add --no-cache \
+    python3 nodejs npm
 
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install
 COPY . .
+RUN chmod a+x /usr/src/app/run.sh
 
-CMD [ "run.sh" ]
+CMD [ "/usr/src/app/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 
-CMD [ "node", "app.js" ]
+CMD [ "/run.sh" ]

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ const config = {
   hassTopic: process.env.HASSTOPIC || 'homeassistant/status',
   spaUser: process.env.CONTROLMYSPA_USER,
   spaPassword: process.env.CONTROLMYSPA_PASS,
-  useCelsius: process.env.CONTROLMYSPA_CELSIUS || true,
+  useCelsius: process.env.CONTROLMYSPA_CELSIUS === 'false' ? false : true,
   refreshSpa: process.env.REFRESH_SPA || 10
 }
 

--- a/app.js
+++ b/app.js
@@ -29,6 +29,8 @@ class App extends EventEmitter {
   constructor(config) {
     super();
 
+    console.log(config)
+
     this.mqtt = mqttApi.connect({
       host: config.mqttHost,
       port: config.mqttPort,

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const config = {
   spaUser: process.env.CONTROLMYSPA_USER,
   spaPassword: process.env.CONTROLMYSPA_PASS,
   useCelsius: process.env.CONTROLMYSPA_CELSIUS === 'false' ? false : true,
-  refreshSpa: process.env.REFRESH_SPA || 10
+  refreshSpa: process.env.REFRESH_SPA ? +process.env.REFRESH_SPA : 10
 }
 
 logDebug(JSON.stringify(config));

--- a/app.js
+++ b/app.js
@@ -29,8 +29,6 @@ class App extends EventEmitter {
   constructor(config) {
     super();
 
-    console.log(config)
-
     this.mqtt = mqttApi.connect({
       host: config.mqttHost,
       port: config.mqttPort,

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.3"
+version: "1.0.4"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.2"
+version: "1.0.3"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,31 @@
+name: "ControlMySpa HA MQTT"
+description: "ControlMySpa MQTT Bridge"
+version: "1.0.0"
+slug: "controlmyspa_ha_mqtt"
+init: false
+arch:
+  - aarch64
+  - amd64
+  - armhf
+  - armv7
+  - i386
+options:
+  mqtt_host:
+  mqtt_port:
+  mqtt_user:
+  mqtt_pass:
+  controlmyspa_user:
+  controlmyspa_pass: "world"
+  controlmyspa_celsius: false
+  hass_topic: homeassistant/status
+  debug: app:info,*:error,spa:info
+schema:
+  mqtt_host: str
+  mqtt_port: int
+  mqtt_user: str
+  mqtt_pass: str
+  controlmyspa_user: str
+  controlmyspa_pass: str
+  controlmyspa_celsius: bool
+  hass_topic: str
+  debug: str

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.1"
+version: "1.0.2"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.0"
+version: "1.0.1"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.4"
+version: "1.0.5"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.6"
+version: "1.0.7"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:
@@ -19,6 +19,7 @@ options:
   controlmyspa_celsius: false
   hass_topic: homeassistant/status
   debug: app:info,*:error,spa:info
+  refresh_spa: 5
 schema:
   mqtt_host: str
   mqtt_port: int
@@ -29,3 +30,4 @@ schema:
   controlmyspa_celsius: bool
   hass_topic: str
   debug: str
+  refresh_spa: int

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ options:
   mqtt_user:
   mqtt_pass:
   controlmyspa_user:
-  controlmyspa_pass: "world"
+  controlmyspa_pass:
   controlmyspa_celsius: false
   hass_topic: homeassistant/status
   debug: app:info,*:error,spa:info

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "ControlMySpa HA MQTT"
 description: "ControlMySpa MQTT Bridge"
-version: "1.0.5"
+version: "1.0.6"
 slug: "controlmyspa_ha_mqtt"
 init: false
 arch:

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+  "name": "ControlMySpa MQTT Repository",
+  "url": "https://github.com/jkrall/controlmyspa-ha-mqtt",
+  "maintainer": "Joshua Krall"
+}

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bashio
 
-MQTTHOST=$(bashio::config 'mqtt_host')
-MQTTPORT=$(bashio::config 'mqtt_port')
-MQTTUSER=$(bashio::config 'mqtt_user')
-MQTTPASS=$(bashio::config 'mqtt_pass')
+MQTTHOST=$(bashio::services mqtt "host")
+MQTTPORT=$(bashio::services mqtt "port")
+MQTTUSER=$(bashio::services mqtt "username")
+MQTTPASS=$(bashio::services mqtt "password")
 CONTROLMYSPA_USER=$(bashio::config 'controlmyspa_user')
 CONTROLMYSPA_PASS=$(bashio::config 'controlmyspa_pass')
 CONTROLMYSPA_CELSIUS=$(bashio::config 'controlmyspa_celsius')

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bashio
 
-export MQTTHOST=$(bashio::services mqtt "host")
-export MQTTPORT=$(bashio::services mqtt "port")
-export MQTTUSER=$(bashio::services mqtt "username")
-export MQTTPASS=$(bashio::services mqtt "password")
+export MQTTHOST=$(bashio::config 'mqtt_host')
+export MQTTPORT=$(bashio::config 'mqtt_port')
+export MQTTUSER=$(bashio::config 'mqtt_user')
+export MQTTPASS=$(bashio::config 'mqtt_pass')
 export CONTROLMYSPA_USER=$(bashio::config 'controlmyspa_user')
 export CONTROLMYSPA_PASS=$(bashio::config 'controlmyspa_pass')
 export CONTROLMYSPA_CELSIUS=$(bashio::config 'controlmyspa_celsius')

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/with-contenv bashio
 
-MQTTHOST=$(bashio::services mqtt "host")
-MQTTPORT=$(bashio::services mqtt "port")
-MQTTUSER=$(bashio::services mqtt "username")
-MQTTPASS=$(bashio::services mqtt "password")
-CONTROLMYSPA_USER=$(bashio::config 'controlmyspa_user')
-CONTROLMYSPA_PASS=$(bashio::config 'controlmyspa_pass')
-CONTROLMYSPA_CELSIUS=$(bashio::config 'controlmyspa_celsius')
-HASSTOPIC=$(bashio::config 'hass_topic')
-DEBUG=$(bashio::config 'debug')
+export MQTTHOST=$(bashio::services mqtt "host")
+export MQTTPORT=$(bashio::services mqtt "port")
+export MQTTUSER=$(bashio::services mqtt "username")
+export MQTTPASS=$(bashio::services mqtt "password")
+export CONTROLMYSPA_USER=$(bashio::config 'controlmyspa_user')
+export CONTROLMYSPA_PASS=$(bashio::config 'controlmyspa_pass')
+export CONTROLMYSPA_CELSIUS=$(bashio::config 'controlmyspa_celsius')
+export HASSTOPIC=$(bashio::config 'hass_topic')
+export DEBUG=$(bashio::config 'debug')
 
 node app.js

--- a/run.sh
+++ b/run.sh
@@ -9,5 +9,6 @@ export CONTROLMYSPA_PASS=$(bashio::config 'controlmyspa_pass')
 export CONTROLMYSPA_CELSIUS=$(bashio::config 'controlmyspa_celsius')
 export HASSTOPIC=$(bashio::config 'hass_topic')
 export DEBUG=$(bashio::config 'debug')
+export REFRESH_SPA=$(bashio::config 'refresh_spa')
 
 node app.js

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/with-contenv bashio
+
+MQTTHOST=$(bashio::config 'mqtt_host')
+MQTTPORT=$(bashio::config 'mqtt_port')
+MQTTUSER=$(bashio::config 'mqtt_user')
+MQTTPASS=$(bashio::config 'mqtt_pass')
+CONTROLMYSPA_USER=$(bashio::config 'controlmyspa_user')
+CONTROLMYSPA_PASS=$(bashio::config 'controlmyspa_pass')
+CONTROLMYSPA_CELSIUS=$(bashio::config 'controlmyspa_celsius')
+HASSTOPIC=$(bashio::config 'hass_topic')
+DEBUG=$(bashio::config 'debug')
+
+node app.js


### PR DESCRIPTION
* the existing repo was 90% the way towards working as a normal add-on via the standard HA addon "store"
* I added config.yaml, repository.json, etc — so that you can add the `https://github.com/jkrall/controlmyspa-ha-mqtt` repository and then install this add-on via the HA UI.
  * if you decide to merge this, you will want to update the `repository.json` file to point to this repo, and change the author
* Also added configuration controls, and changed the Dockerfile & run script so that it works w/ the HA supervisor
* Finally, added two fixes in app.js for celsius and update-frequency settings, which were not working w/ string environment variable configs

... feel free to merge this in, if you'd like to enable this repo to be broadly used as a Home Assistant addon!  Otherwise, my fork works perfectly fine for me.  :)

Thanks for doing the hard-work here to get this working — I'm super happy to have found your repo and have gotten it to work w/ my spa.